### PR TITLE
Add typescript to demo package.json and add more descriptive filters for demo/src/dialog.tab.ts

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -16,6 +16,7 @@
         "electron": "^16.0.4",
         "lite-server": "^2.6.1",
         "ts-loader": "^9.2.6",
+        "typescript": "^4.6.2",
         "webpack": "^5.65.0",
         "webpack-cli": "^4.9.1"
       }
@@ -4105,6 +4106,19 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
@@ -7781,6 +7795,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -19,6 +19,7 @@
     "electron": "^16.0.4",
     "lite-server": "^2.6.1",
     "ts-loader": "^9.2.6",
+    "typescript": "^4.6.2",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1"
   }

--- a/demo/src/dialog.tab.ts
+++ b/demo/src/dialog.tab.ts
@@ -19,7 +19,7 @@ export class DialogTab extends AbstractTab {
                 title: 'My Awesome Dialog',
                 properties: ['openFile'],
                 filters: [
-                    {name: 'Awesome File', extensions: ['txt', 'json']}
+                    {name: 'Awesome File (txt or json)', extensions: ['txt', 'json']}
                 ]
             }).then(result => {
                 if (result.canceled || result.filePaths.length !== 1) {


### PR DESCRIPTION
I found this repository while searching for an electron dialog bridge. This works great for what I'm using it for, but I had some small issues setting up the demo. `npm build` would not run because typescript wasn't installed. After I installed that, the demo worked perfectly.

I also thought it would be a good idea to make the filter name more descriptive. When trying to open a file, some file managers (like [Thunar](https://wiki.archlinux.org/title/thunar)) do not show the extension and only show the name which is somewhat confusing. 

![image](https://user-images.githubusercontent.com/88910588/156882453-ed12593e-2f17-4c6b-8dcb-0a9dd9fb726b.png)

Other than that, this bridge works great. Thanks for making this. I was looking forever for something like this.
